### PR TITLE
Optimize logging

### DIFF
--- a/include/smlib/desktop.ini
+++ b/include/smlib/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files\Google\Drive\googledrivesync.exe
-IconIndex=16
-    

--- a/shavit-bash2.sp
+++ b/shavit-bash2.sp
@@ -189,12 +189,20 @@ bool g_bAdminMode[MAXPLAYERS + 1];
 char g_sHostName[128];
 char g_sWebhook[255];
 
+char g_aclogfile[PLATFORM_MAX_PATH];
+char g_sPlayerIp[128];
+
 //shavit
 stylesettings_t g_aStyleSettings[STYLE_LIMIT];
 stylestrings_t g_sStyleStrings[STYLE_LIMIT];
 
 public void OnPluginStart()
 {
+	char sDate[64];
+	FormatTime(sDate, sizeof(sDate), "%y%m%d", GetTime());
+	
+	BuildPath(Path_SM, g_aclogfile, PLATFORM_MAX_PATH, "logs/ac_%s.txt", sDate);
+
 	UserMsg umVGUIMenu = GetUserMessageId("VGUIMenu");
 	if (umVGUIMenu == INVALID_MESSAGE_ID)
 		SetFailState("UserMsg `umVGUIMenu` not found!");
@@ -465,37 +473,7 @@ stock bool AnticheatLog(int client, const char[] log, any ...)
 		PrintToDiscord(client, buffer);
 	}
 	
-	Handle myHandle = GetMyHandle();
-	char sPlugin[PLATFORM_MAX_PATH];
-	GetPluginFilename(myHandle, sPlugin, PLATFORM_MAX_PATH);
-	
-	char sPlayer[128];
-	GetClientAuthId(client, AuthId_Steam2, sPlayer, sizeof(sPlayer));
-	
-	char sPlayerIp[32];
-	GetClientIP(client, sPlayerIp, sizeof(sPlayerIp));
-	Format(sPlayer, sizeof(sPlayer), "%N<%s><%s>", client, sPlayer, sPlayerIp);
-	
-	char sTime[64];
-	FormatTime(sTime, sizeof(sTime), "%X", GetTime());
-	Format(buffer, 1024, "[%s] %s: %s %s", sPlugin, sTime, sPlayer, buffer);
-	
-	char sDate[64];
-	FormatTime(sDate, sizeof(sDate), "%y%m%d", GetTime());
-	char sPath[PLATFORM_MAX_PATH];
-	BuildPath(Path_SM, sPath, sizeof(sPath), "logs/ac_%s.txt", sDate);
-	File hFile = OpenFile(sPath, "a");
-	if(hFile != INVALID_HANDLE)
-	{
-		WriteFileLine(hFile, buffer);
-		delete hFile;
-		return true;
-	}
-	else
-	{
-		LogError("Couldn't open timer log file.");
-		return false;
-	}
+	LogToFile(g_aclogfile, "%L<%s> %s", client, g_sPlayerIp, buffer);
 }
 
 public Action Event_PlayerJump(Event event, const char[] name, bool dontBroadcast)
@@ -579,6 +557,7 @@ public void OnMapStart()
 		{
 			if(IsClientInGame(iclient))
 			{
+				OnClientConnected(iclient);
 				OnClientPutInServer(iclient);
 			}
 		}
@@ -596,6 +575,11 @@ public Action Timer_UpdateYaw(Handle timer, any data)
 			QueryForCvars(iclient);
 		}
 	}
+}
+
+public void OnClientConnected(int client)
+{
+	GetClientIP(client, g_sPlayerIp, sizeof(g_sPlayerIp));
 }
 
 public void OnClientPostAdminCheck(int client) 


### PR DESCRIPTION
This significantly optimizes BASH's logging. As it stands, there are a lot of unnecessary functions called every single time the AC log is requested to be written, this rids most of it.

The only "significant" change is the format, which is very minor:
Before:
`[shavit-bash2.smx] 13:03:25: .sneaK<STEAM_1:0:4040087><IPADDRESS> key switch 0, avg: 0.36, dev: 1.58, p: 0.00％, nullPct: 88.00, Timing: 100.0, Style: Normal`

After:
`L 09/30/2020 - 13:05:48: [shavit-bash2.smx] .sneaK<6><STEAM_1:0:4040087><><IPADDRESS> key switch 1, avg: 0.37, dev: 0.93, p: 100.00％, nullPct: 80.00, Timing: 100.0, Style: Normal`