### PR TITLE
Make Discord API presence optional

### DIFF
--- a/shavit-bash2.sp
+++ b/shavit-bash2.sp
@@ -1,5 +1,4 @@
 #define TIMER
-#define DISCORD
 
 #include <sourcemod>
 #include <sdktools>
@@ -11,9 +10,8 @@
 #include <shavit>
 #endif
 
-#if defined DISCORD
+#undef REQUIRE_PLUGIN
 #include <discord>
-#endif
 
 #undef REQUIRE_EXTENSIONS
 #include <dhooks>
@@ -277,9 +275,15 @@ public void OnLibraryRemoved(const char[] name)
 	{
 		//g_bTasLoaded = false;
 	}
+	
 	else if(StrEqual(name, "dhooks"))
 	{
 		g_bDhooksLoaded = false;
+	}
+	
+	if(StrEqual(name, "discord-api"))
+	{
+		g_bDiscordLoaded = false;
 	}
 	
 	#if defined TIMER
@@ -418,12 +422,10 @@ void SaveOldLogs()
 	DeleteFile(sPath);
 }
 
-stock bool PrintToDiscord(int client, const char[] log, any ...)
+public void PrintToDiscord(int client, const char[] log, any ...)
 {
 	if(g_bDiscordLoaded)
 	{
-		#if defined DISCORD
-		
 		char clientName[32];
 		GetClientName(client, clientName, 32);
 		
@@ -449,10 +451,7 @@ stock bool PrintToDiscord(int client, const char[] log, any ...)
 		
 		hook.Send();
 		delete hook;
-		return true;
-		#endif
 	}
-	return false;
 }
 
 stock bool AnticheatLog(int client, const char[] log, any ...)
@@ -461,7 +460,7 @@ stock bool AnticheatLog(int client, const char[] log, any ...)
 	VFormat(buffer, sizeof(buffer), log, 3);
 	PrintToAdmins("%N %s", client, buffer);
 	
-	if(g_hLogToDiscord.BoolValue && LibraryExists("discord-api") && !g_hOnlyPrintBan.BoolValue) {
+	if(g_hLogToDiscord.BoolValue && g_bDiscordLoaded && !g_hOnlyPrintBan.BoolValue) {
 		PrintToDiscord(client, buffer);
 	}
 	


### PR DESCRIPTION
Title, this makes usage of Discord API entirely optional. Changes unnecessary boolean to void (return wasn't being used anywhere), changes library check to cached boolean, adds OnLibraryRemoved check, and removes compile-time define.

Until the PR is accepted, this requires https://github.com/Deathknife/sourcemod-discord/pull/24 due to the library includes not being marked optional.