### PR TITLE
fix joystick messages printing randomly on player join

### DIFF
--- a/shavit-bash2.sp
+++ b/shavit-bash2.sp
@@ -786,6 +786,9 @@ public void OnClientConnected(int client)
 	g_ZoomSensitivityCheckedCount[client] = 0;
 	
 	g_iLastInvalidButtonCount[client] = 0;
+	
+	g_JoyStick[client] = false;
+	g_JoyStickChangedCount[client] = 0;
 }
 
 public void OnClientPostAdminCheck(int client) 


### PR DESCRIPTION
`g_JoyStickChangedCount` is never cleared so it "randomly" prints the joystick message when people join