### PR TITLE
reliable stream overflow causing disconnects when network state gets interrupted

### DIFF
--- a/shavit-bash2.sp
+++ b/shavit-bash2.sp
@@ -1046,7 +1046,7 @@ public Action Hook_GroundFlags(int entity, const char[] PropName, int &iValue, i
 //this fixes client disconnects due to QueryForCvars overflowing the reliable stream during network interruption
 #define MAX_CONVARS 12
 
-enum QueryConVars
+enum
 {
     CONVAR_YAWSPEED,
     CONVAR_YAW,


### PR DESCRIPTION
we are trying to query for more cvars when the last query failed, the client overflows when they reconnect