### PR TITLE
Conditional query optimization? Does this break anything?

### DIFF
--- a/shavit-bash2.sp
+++ b/shavit-bash2.sp
@@ -1046,7 +1046,7 @@ public Action Hook_GroundFlags(int entity, const char[] PropName, int &iValue, i
 //this fixes client disconnects due to QueryForCvars overflowing the reliable stream during network interruption
 #define MAX_CONVARS 12
 
-enum QueryConVars
+enum
 {
     CONVAR_YAWSPEED,
     CONVAR_YAW,


### PR DESCRIPTION
This is built on top of my other PR: https://github.com/hermansimensen/bash2/pull/32

Do we need to be querying `m_customaccel`, `m_customaccel_exponent`, `m_customaccel_scale`, `m_customaccel_max`, `m_filter` if `m_rawinput` is not 0? The values of these cvars do nothing if `m_rawinput` is set to 1.

Additionally, I have made `joy_yawsensitivity` querying conditional based on `joystick 1`